### PR TITLE
edit travis and gitignore & fix tests (#1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 .idea
 vendor
-composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,30 +11,22 @@ cache:
 
 matrix:
   include:
-    - php: 5.5
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.6
-      env: SYMFONY_VERSION=2.8.*
     - php: 7.0
-      env: SYMFONY_VERSION=2.8.*
-    - php: 5.5
-      env: SYMFONY_VERSION=3.0.*
-    - php: 5.6
-      env: SYMFONY_VERSION=3.0.*
-    - php: 7.0
-      env: SYMFONY_VERSION=3.0.*
-    - php: hhvm
-      env: SYMFONY_VERSION=2.8.*
-  allow_failures:
-    - php: hhvm
+      env: SYMFONY_VERSION=v3
+    - php: 7.1
+      env: SYMFONY_VERSION=v3
+    - php: 7.2
+      env: SYMFONY_VERSION=v3
+    - php: 7.1
+      env: SYMFONY_VERSION=v4
+    - php: 7.2
+      env: SYMFONY_VERSION=v4
 
 before_install:
     - composer self-update
-    - if [[ "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then INI_FILE=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; else INI_FILE=/etc/hhvm/php.ini; fi;
 
 install:
-    - composer require symfony/symfony:${SYMFONY_VERSION} --no-update
-    - composer require "php-http/guzzle6-adapter:^1.0" --no-update
+    - composer require dunglas/symfony-lock:${SYMFONY_VERSION} --no-update
     - composer install --prefer-source
 
 script:
@@ -42,4 +34,4 @@ script:
 
 notifications:
   email:
-    - liam@eezeecommerce.com
+    - dan@eezeecommerce.com

--- a/Tests/ApiTest.php
+++ b/Tests/ApiTest.php
@@ -101,7 +101,7 @@ class ApiTest extends \PHPUnit_Framework_TestCase
             "mode" => "mode",
             "password" => "password"
         ), $this->createHttpClientMock(), $this->createHttpMessageFactory());
-        $this->assertEquals('https://www.ipg-online.com/vt/login', $api->getApiEndpoint());
+        $this->assertEquals('https://www.ipg-online.com/connect/gateway/processing', $api->getApiEndpoint());
     }
     /**
      * @test

--- a/Tests/CardnetHostedGatewayFactoryTest.php
+++ b/Tests/CardnetHostedGatewayFactoryTest.php
@@ -98,6 +98,10 @@ class CardnetHostedGatewayFactoryTest extends \PHPUnit_Framework_TestCase
         $factory = new CardnetHostedGatewayFactory(array(
             'foo' => 'fooVal',
             'bar' => 'barVal',
+            'txntype' => '',
+            'storename' => '',
+            "shared_secret" => "",
+            'mode' => ''
         ));
         $config = $factory->createConfig();
         $this->assertInternalType('array', $config);
@@ -134,7 +138,7 @@ class CardnetHostedGatewayFactoryTest extends \PHPUnit_Framework_TestCase
      * @test
      *
      * @expectedException \Payum\Core\Exception\LogicException
-     * @expectedExceptionMessage The sandbox, txntype, storename, shared_secret, mode fields are required.
+     * @expectedExceptionMessage The txntype, storename, shared_secret, mode fields are required.
      */
     public function shouldThrowIfRequiredOptionsNotPassed()
     {


### PR DESCRIPTION
Fixes for the tests fix for the .gitignore to enable uploading of the composer.lock file to ensure installing the same version as tested. Also, changed travis versions to test against LTS and currently supported Symfony versions. Also, updated with shorter syntax.